### PR TITLE
Add edge-light export and functionality

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "exports": {
     ".": {
       "types": "./source/index.d.ts",
+      "edge-light": "./source/index.js",
       "import": "./source/index.js"
     }
   },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "exports": {
     ".": {
       "types": "./source/index.d.ts",
-      "edge-light": "./source/index.js",
+      "edge-light": "./source/edge-light/index.js",
       "import": "./source/index.js"
     }
   },

--- a/source/edge-light/index.js
+++ b/source/edge-light/index.js
@@ -1,0 +1,69 @@
+import {is} from '@yurkimus/types'
+import {media} from "../index.js";
+
+export * from "../index.js"
+
+/**
+ * Parse the body of HTTP-message
+ */
+export let body = message => {
+
+  console.log('EdgeRuntime test')
+
+  for (let property of ['text', 'json', 'formData']) {
+    if (!(property in message && typeof message[property] === "function")) throw new TypeError(
+      `Parameter 'message' must be on of: `
+      + `'${['Request', 'Response'].join(', ')}'.`,
+    )
+  }
+
+  switch (media(message)) {
+    case '':
+      return Promise.resolve(null)
+
+    case 'text/plain':
+      return message.text()
+
+    case 'application/json':
+      return message.json()
+
+    case 'multipart/form-data':
+    case 'application/x-www-form-urlencoded':
+      return message.formData()
+
+    default:
+      throw new TypeError(
+        `No handler found for media-type '${media(message)}'.`,
+      )
+  }
+}
+
+/**
+ * Clone HTTP-message
+ */
+export let clone = message => {
+  if (!['Request', 'Response'].some(kind => is(kind, message)))
+    throw new TypeError(
+      `Parameter 'message' must be on of: `
+      + `'${['Request', 'Response'].join(', ')}'.`,
+    )
+
+  return [message, message.clone()]
+}
+
+/**
+ * Clone and read the body of HTTP-mesage
+ */
+export let read = message => {
+  if (!['Request', 'Response'].some(kind => is(kind, message)))
+    throw new TypeError(
+      `Parameter 'message' must be on of: `
+      + `'${['Request', 'Response'].join(', ')}'.`,
+    )
+
+  return Promise
+    .resolve(message)
+    .then(clone)
+    .then(([message, clone]) => [message, body(clone)])
+    .then(Promise.all.bind(Promise))
+}

--- a/source/edge-light/index.js
+++ b/source/edge-light/index.js
@@ -65,7 +65,6 @@ export let clone = message => {
  * Clone and read the body of HTTP-mesage
  */
 export let read = message => {
-  console.log('EdgeRuntime test')
   return Promise
     .resolve(message)
     .then(clone)

--- a/source/edge-light/index.js
+++ b/source/edge-light/index.js
@@ -1,6 +1,21 @@
-import {media} from "../index.js";
-
 export * from "../index.js"
+
+/**
+ * Get the media-type of HTTP-message
+ */
+export let media = message => {
+  for (let property of ['headers']) {
+    if (!(property in message)) throw new TypeError(
+      `Parameter ‘message’ must have ‘headers’ property.`
+    )
+  }
+
+  return message.headers
+      .get('Content-Type')
+      ?.split(';')
+      ?.at(0)
+    ?? ''
+}
 
 /**
  * Parse the body of HTTP-message

--- a/source/edge-light/index.js
+++ b/source/edge-light/index.js
@@ -1,4 +1,3 @@
-import {is} from '@yurkimus/types'
 import {media} from "../index.js";
 
 export * from "../index.js"
@@ -7,13 +6,9 @@ export * from "../index.js"
  * Parse the body of HTTP-message
  */
 export let body = message => {
-
-  console.log('EdgeRuntime test')
-
   for (let property of ['text', 'json', 'formData']) {
     if (!(property in message && typeof message[property] === "function")) throw new TypeError(
-      `Parameter 'message' must be on of: `
-      + `'${['Request', 'Response'].join(', ')}'.`,
+      `Parameter 'message' must have ‘text’, ‘json’ and ‘formData’ methods.`
     )
   }
 
@@ -42,11 +37,11 @@ export let body = message => {
  * Clone HTTP-message
  */
 export let clone = message => {
-  if (!['Request', 'Response'].some(kind => is(kind, message)))
-    throw new TypeError(
-      `Parameter 'message' must be on of: `
-      + `'${['Request', 'Response'].join(', ')}'.`,
+  for (let property of ['clone']) {
+    if (!(property in message && typeof message[property] === "function")) throw new TypeError(
+      `Parameter ‘message’ must have ‘clone’ method.`
     )
+  }
 
   return [message, message.clone()]
 }
@@ -55,12 +50,7 @@ export let clone = message => {
  * Clone and read the body of HTTP-mesage
  */
 export let read = message => {
-  if (!['Request', 'Response'].some(kind => is(kind, message)))
-    throw new TypeError(
-      `Parameter 'message' must be on of: `
-      + `'${['Request', 'Response'].join(', ')}'.`,
-    )
-
+  console.log('EdgeRuntime test')
   return Promise
     .resolve(message)
     .then(clone)


### PR DESCRIPTION
Introduced a new "edge-light" export in package.json to point to a newly created edge-light index in the source directory. This includes implementations for parsing, cloning, and reading HTTP message bodies, supporting different media types and handling accordingly.